### PR TITLE
feat(ci): add final autodeploy.yml per spec Setup Auto Deploy Workflow)

### DIFF
--- a/github/workflows/autodeploy.yml
+++ b/github/workflows/autodeploy.yml
@@ -1,0 +1,67 @@
+name: Auto Deploy
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Preflight SSH & Secrets Validation
+        run: |
+          if [ -z "${{ secrets.DEPLOY_KEY }}" ]; then
+            echo "❌ Missing DEPLOY_KEY secret"
+            exit 1
+          fi
+          echo "✅ Secrets validated"
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H your-server.com >> ~/.ssh/known_hosts
+
+      - name: Prepare APP_DIR
+        run: |
+          APP_DIR=/var/www/nursery-system
+          mkdir -p $APP_DIR
+          cd $APP_DIR
+          git config --global --add safe.directory $APP_DIR
+
+          if [ ! -d .git ]; then
+            echo "⚡ Initializing repository"
+            git init
+            git remote add origin git@github.com:alzaem2002-ctrl/nursery-management-system-dari-alhanonah-system.git
+          fi
+
+          git fetch origin main
+          git checkout main || git checkout -b main
+          git reset --hard origin/main
+
+      - name: Clean stale submodule config
+        run: |
+          if [ ! -f .gitmodules ]; then
+            echo "🧹 Cleaning stale submodule config"
+            git config --remove-section submodule.webapp || true
+          else
+            echo "🔗 Updating submodules"
+            git submodule sync --recursive
+            git submodule update --init --recursive
+          fi
+
+      - name: Install & Build
+        run: |
+          cd /var/www/nursery-system
+          npm ci
+          npm run build --if-present
+
+      - name: Restart Service
+        run: |
+          cd /var/www/nursery-system
+          pm2 restart ecosystem.config.cjs || pm2 start ecosystem.config.cjs


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a GitHub Actions workflow to validate secrets, sync `main`, build with npm, and restart the app via PM2.
> 
> - **CI/CD**: Add auto-deploy workflow in `github/workflows/autodeploy.yml`.
>   - Triggers on `push`/`pull_request` to `main`; runs on `ubuntu-latest` with 30-min timeout.
>   - Validates `DEPLOY_KEY` secret and configures SSH known hosts.
>   - Prepares and syncs repo in `/var/www/nursery-system` (`git init`, set `origin`, fetch/checkout/reset `main`).
>   - Handles submodules: sync and `update --init --recursive` when `.gitmodules` exists; cleans stale config otherwise.
>   - Build: `npm ci` and `npm run build --if-present`.
>   - Deploy: restart or start via PM2 using `ecosystem.config.cjs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca6986cd17233d65f4d6a88850ea6f689a9cbc2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->